### PR TITLE
feat: gzip webhook format on intro

### DIFF
--- a/docs/webhooks/introduction.md
+++ b/docs/webhooks/introduction.md
@@ -74,3 +74,17 @@ Acesse nosso painel admin, em Instâncias clique no olho "visualizar" na instân
 ### Via api
 
 Também é possível atualizar a rota do seu webhook chamando o endpoint de update. Esse endpoint é disponibilizado nos próximos tópicos da documentação.
+
+---
+
+## Formato Gzip
+
+A compactação Gzip pode diminuir bastante o tamanho do corpo de resposta e assim aumentar a velocidade de um aplicativo da web.
+
+Diante disso, em novembro de 2024 foi lançada uma atualização do Z-API em que os webhooks poderão ser recebidos no formato Gzip.
+
+Para isso, você vai precisar descomprimir os dados do webhook que chegarão no formato Gzip. Mas não se preocupe, vamos te auxiliar abaixo.
+
+### Como descompactar Gzip
+
+Para auxiliá-los nesse processo, criamos um repositório com diversas aplicações que descompactam o Gzip utilizando diferentes linguagens e frameworks. Para saber mais, acesse o [link do repositório](https://github.com/Z-API/z-api-gzip-decompress).

--- a/i18n/en/docusaurus-plugin-content-docs/current/webhooks/introduction.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/webhooks/introduction.md
@@ -67,3 +67,22 @@ Acesse nosso painel admin, vá em opções e escolha "editar instância".
 Access our admin panel, go to options and choose "edit instance"
 
 ![img](../../../../../img/EditInstance.jpeg)
+
+
+### API
+
+You can also update your webhook's rotation by calling the update endpoint. This endpoint is available in the detailed documentation details.
+
+---
+
+## Gzip format
+
+Gzip compression can greatly decrease the size of the response body and thus increase the speed of a web application.
+
+Therefore, in November 2024 an update to the Z-API was released in which webhooks can be received in Gzip format.
+
+To do this, you will need to decompress the webhook data that will arrive in Gzip format. But don't worry, we'll help you below.
+
+### How unzip Gzip
+
+To assist you in this process, we created a repository with several applications that decompress Gzip using different languages ​​and frameworks. To learn more, visit [repository link](https://github.com/Z-API/z-api-gzip-decompress).


### PR DESCRIPTION
## Descrição

- Foi documentado sobre o formato Gzip nos webhooks, explicando a motivação para a troca, além de referenciar o link do repositório para ajudar na troca.

O link do repositório de aplicações que auxiliam na descompressão é o https://github.com/Z-API/z-api-gzip-decompress