### PR TITLE
feat: async parameter on send audio msg

### DIFF
--- a/docs/message/send-message-audio.md
+++ b/docs/message/send-message-audio.md
@@ -52,6 +52,7 @@ Neste [link] você encontra tudo que precisa saber sobre formatos e tamanhos de 
 | delayMessage | number | Nesse atributo um delay é adicionado na mensagem. Você pode decidir entre um range de 1~15 sec, significa quantos segundos ele vai esperar para enviar a próxima mensagem. (Ex "delayMessage": 5, ). O delay default caso não seja informado é de 1~3 sec |
 | delayTyping  | number | Nesse atributo um delay é adicionado na mensagem. Você pode decidir entre um range de 1~15 sec, significa quantos segundos ele vai ficar com o status "Gravando áudio...". (Ex "delayTyping": 5, ). O delay default caso não seja informado é de 0|
 | viewOnce | boolean | Define se será uma mensagem de visualização única ou não |
+| async | boolean | Se ativo, a request responderá imediatamente com sucesso e o processamento do arquivo será realizado em segundo plano. O envio pode ser verificado através do [webhook de envio](/webhooks/on-message-send). |
 
 ---
 

--- a/docs/message/send-message-video.md
+++ b/docs/message/send-message-video.md
@@ -53,6 +53,7 @@ Neste [link] você encontra tudo que precisa saber sobre formatos e tamanhos de 
 | delayMessage | number | Nesse atributo um delay é adicionado na mensagem. Você pode decidir entre um range de 1~15 sec, significa quantos segundos ele vai esperar para enviar a próxima mensagem. (Ex "delayMessage": 5, ). O delay default caso não seja informado é de 1~3 sec |
 | caption | String | Mensagem em que desejar enviar, junto com o vídeo |
 | viewOnce | boolean | Define se será uma mensagem de visualização única ou não |
+| async | boolean | Se ativo, a request responderá imediatamente com sucesso e o processamento do arquivo será realizado em segundo plano. O envio pode ser verificado através do [webhook de envio](/webhooks/on-message-send). |
 
 ---
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/message/send-message-audio.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/message/send-message-audio.md
@@ -53,6 +53,7 @@ In this [link]  you can find everything that you need to know about formatting a
 | messageId | String | Attribute used to answer a chat message. All you have to do is add the messageID of the message that you want to respond to this attribute |
 | delayMessage | number | In this attribute a delay is added to the message. You can decide between a range of 1 - 15 secs (this is for how many seconds it will wait to send the next message EX: “delayMessage”:5,). The default delay is between 1 - 3 secs. |
 | viewOnce | boolean | Defines wether it will be a view once message or not |
+| async | boolean | If enabled, the request will immediately respond with success, and the file processing will be performed in the background. The sending process can be tracked through [delivery webhook](/webhooks/on-message-send). |
 
 ---
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/message/send-message-video.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/message/send-message-video.md
@@ -53,6 +53,7 @@ In this [link] you can find everything that you need to know about formatting an
 | delayMessage | number | In this attribute a delay is added to the message. You can decide between a range of 1 - 15 secs (this is for how many seconds it will wait to send the next message EX: “delayMessage”:5,). The default delay is between 1 - 3 secs. |
 | caption | String | Message that you wish to send along with the video|
 | viewOnce | boolean | Defines wether it will be a view once message or not |
+| async | boolean | If enabled, the request will immediately respond with success, and the file processing will be performed in the background. The sending process can be tracked through [delivery webhook](/webhooks/on-message-send). |
 
 
 ---


### PR DESCRIPTION
Adicionado nos parâmetros opcionais do envio de mensagem de áudio e de mensagem de vídeo.

## Envio de áudio
<img width="1168" alt="image" src="https://github.com/user-attachments/assets/2abb8951-b912-43aa-9982-dc9ed9536071">


## Envio de vídeo
<img width="1166" alt="image" src="https://github.com/user-attachments/assets/7d11464a-8cfb-441e-97a4-215d7533862a">
