### PR TITLE
Add docs for updating community description

### DIFF
--- a/docs/communities/update-community-description.md
+++ b/docs/communities/update-community-description.md
@@ -1,0 +1,91 @@
+---
+id: update-community-description
+title: Alterar descrição
+---
+
+## Método
+
+#### /update-community-description
+
+`POST` https://api.z-api.io/instances/SUA_INSTANCIA/token/SEU_TOKEN/update-community-description
+
+### Header
+
+|      Key       |            Value            |
+| :------------: |     :-----------------:     |
+|  Client-Token  | **[TOKEN DE SEGURANÇA DA CONTA](../security/client-token)** |
+---
+
+## Conceituação
+
+Este método permite você alterar a descrição da comunidade.
+
+:::caution Atenção
+
+Atenção somente administradores podem alterar as preferências da comunidade.
+
+:::
+
+---
+
+## Atributos
+
+### Obrigatórios
+
+| Atributos            |  Tipo  | Descrição                                       |
+| :------------------- | :----: | :---------------------------------------------- |
+| communityId          | string | ID/Fone do grupo                                |
+| communityDescription | string | Atributo para alterar a descrição da comunidade |
+
+---
+
+#### Body
+
+```json
+
+  {
+    "communityId": "120363019502650977",
+    "communityDescription": "descrição da comunidade"
+  }
+
+```
+
+---
+
+## Response
+
+### 200
+
+| Atributos | Tipo    | Descrição                                           |
+| :-------- | :------ | :-------------------------------------------------- |
+| value     | boolean | true caso tenha dado certo e false em caso de falha |
+
+**Exemplo**
+
+```json
+{
+  "value": true
+}
+```
+
+### 405
+
+Neste caso certifique que esteja enviando o corretamente a especificação do método, ou seja verifique se você enviou o POST ou GET conforme especificado no inicio deste tópico.
+
+### 415
+
+Caso você receba um erro 415, certifique de adicionar na headers da requisição o "Content-Type" do objeto que você está enviando, em sua grande maioria "application/json"
+
+---
+
+## Webhook Response
+
+Link para a response do webhook (ao receber)
+
+[Webhook](../webhooks/on-message-received#response)
+
+---
+
+## Code
+
+<iframe src="//api.apiembed.com/?source=https://raw.githubusercontent.com/Z-API/z-api-docs/main/json-examples/update-community-description.json&targets=all" frameborder="0" scrolling="no" width="100%" height="500px" seamless></iframe>

--- a/i18n/en/docusaurus-plugin-content-docs/current/communities/update-community-description.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/communities/update-community-description.md
@@ -1,0 +1,92 @@
+---
+id: update-community-description
+title: Edit description 
+---
+
+## Method
+
+#### /update-community-description
+
+`POST` https://api.z-api.io/instances/YOUR_INSTANCE/token/YOUR_TOKEN/update-community-description
+
+### Header
+
+|      Key       |            Value            |
+| :------------: |     :-----------------:     |
+|  Client-Token  | **[ACCOUNT SECURITY TOKEN](../security/client-token)** |
+
+---
+
+## Concept
+
+This method allows you to change your community's description
+
+:::caution Attention
+
+Attention only admins can change community preferences.
+
+:::
+
+---
+
+## Attributes
+
+### Required
+
+| Attributes       |  Type  | Description                                    |
+| :--------------- | :----: | :-----------------------------------------     |
+| communityId      | string | Community ID.                                  |
+| communityDescription | string | Attribute to edit the community’s description  |
+
+---
+
+#### Body
+
+```json
+
+  {
+    "communityId": "120363019502650977",
+    "communityDescription": "descrição da comunidade"
+  }
+
+```
+
+---
+
+## Response
+
+### 200
+
+| Attributes| Type    | Description                                           |
+| :-------- | :------ | :-------------------------------------------------- |
+| value     | boolean | true if it worked and false if it failed |
+
+**Example**
+
+```json
+{
+  "value": true
+}
+```
+
+### 405
+
+In this case certify that you are sending the correct specification of the method. This means, verify if you sent a POST or GET as specified at the beginning of this topic.
+
+### 415
+
+In case you receive 415 error, make sure to add the “Content-Type” of the object you are sending in the request headers, mostly “application/json”
+
+---
+
+## Webhook Response
+
+Link to webhook response (on receipt)
+
+[Webhook](../webhooks/on-message-received#response)
+
+---
+
+## Code
+
+<iframe src="//api.apiembed.com/?source=https://raw.githubusercontent.com/Z-API/z-api-docs/main/json-examples/update-community-description.json&targets=all" frameborder="0" scrolling="no" width="100%" height="500px" seamless></iframe>

--- a/json-examples/update-community-description.json
+++ b/json-examples/update-community-description.json
@@ -1,0 +1,21 @@
+{
+  "method": "POST",
+  "url": "https://api.z-api.io/instances/SUA_INSTANCIA/token/SEU_TOKEN/update-community-description",
+  "httpVersion": "HTTP/1.1",
+  "queryString": [],
+  "headers": [
+    {
+      "name": "Content-Type",
+      "value": "application/json"
+    },
+    {
+      "name": "Client-Token",
+      "value": "{{security-token}}"
+    }
+  ],
+  "cookies": [],
+  "postData": {
+    "mimeType": "application/json",
+    "text": "{\"communityId\": \"120363019502650977\",\"communityDescription\": \"descrição da comunidade\"}"
+  }
+}

--- a/sidebars.js
+++ b/sidebars.js
@@ -184,6 +184,7 @@ module.exports = {
       'communities/remove-community-admin',
       'communities/community-settings',
       'communities/deactivate-community',
+      'communities/update-community-description',
     ],
     'Meta AI': ['metaai/introduction', 'metaai/conversation'],
     Newsletter: [


### PR DESCRIPTION
Added new documentation in both Portuguese and English for the /update-community-description API endpoint, including usage, required attributes, responses, and example JSON. Updated the sidebar to include the new documentation and added a corresponding JSON example.