### PR TITLE
Add update community photo API documentation

### DIFF
--- a/docs/communities/update-community-photo.md
+++ b/docs/communities/update-community-photo.md
@@ -1,0 +1,103 @@
+---
+id: update-community-photo
+title: Atualizar imagem da comunidade
+---
+
+## Método
+
+#### /update-community-photo
+
+`POST` https://api.z-api.io/instances/SUA_INSTANCIA/token/SEU_TOKEN/update-community-photo
+
+### Header
+
+|      Key       |            Value            |
+| :------------: |     :-----------------:     |
+|  Client-Token  | **[TOKEN DE SEGURANÇA DA CONTA](../security/client-token)** |
+---
+
+## Conceituação
+
+Este método é responsável alterar a imagem de uma comunidade já existente.
+
+
+---
+
+## Atributos
+
+### Obrigatórios
+
+| Atributos     |  Tipo  | Descrição                  |
+| :------------ | :----: |:---------------------------|
+| communityId   | string | ID da comunidade           |
+| communityPhoto| string | Url ou Base64 da imagem    |
+
+### Opcionais
+
+| Atributos | Tipo | Descrição |
+| :-------- | :--: | :-------- |
+
+---
+
+## Request Body
+
+#### URL
+
+Método
+
+`POST` https://api.z-api.io/instances/SUA_INSTANCIA/token/SEU_TOKEN/update-community-photo
+
+#### Body
+
+```json
+{
+  "communityId": "string",
+  "communityPhoto": "https://www.z-api.io/wp-content/themes/z-api/dist/images/logo.svg"
+}
+```
+
+::::tip Enviar imagem Base64
+
+Se você tem duvidas em como enviar uma imagem Base64 acesse o tópico mensagens "Enviar Imagem", lá você vai encontrar tudo que precisa saber sobre envio neste formato.
+
+::::
+
+---
+
+## Response
+
+### 200
+
+| Atributos | Tipo    | Descrição                                           |
+| :-------- | :------ | :-------------------------------------------------- |
+| value     | boolean | true caso tenha dado certo e false em caso de falha |
+
+Exemplo
+
+```json
+{
+  "value": true
+}
+```
+
+### 405
+
+Neste caso certifique que esteja enviando o corretamente a especificação do método, ou seja verifique se você enviou o POST ou GET conforme especificado no inicio deste tópico.
+
+### 415
+
+Caso você receba um erro 415, certifique de adicionar na headers da requisição o "Content-Type" do objeto que você está enviando, em sua grande maioria "application/json"
+
+---
+
+## Webhook Response
+
+Link para a response do webhook (ao receber)
+
+[Webhook](../webhooks/on-message-received#response)
+
+---
+
+## Code
+
+<iframe src="//api.apiembed.com/?source=https://raw.githubusercontent.com/Z-API/z-api-docs/main/json-examples/update-community-photo.json&targets=all" frameborder="0" scrolling="no" width="100%" height="500px" seamless></iframe>

--- a/i18n/en/docusaurus-plugin-content-docs/current/communities/update-community-photo.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/communities/update-community-photo.md
@@ -1,0 +1,103 @@
+---
+id: update-community-photo
+title: Update community image 
+---
+
+## Method 
+
+#### /update-community-photo
+
+`POST` https://api.z-api.io/instances/YOUR_INSTANCE/token/YOUR_TOKEN/update-community-photo
+
+### Header
+
+|      Key       |            Value            |
+| :------------: |     :-----------------:     |
+|  Client-Token  | **[ACCOUNT SECURITY TOKEN](../security/client-token)** |
+
+---
+
+## Concept 
+
+This method is reponsibible for changing a community image that already exists
+
+---
+
+## Atributes
+
+### Required
+
+| Attributes    |  Type  | Description           |
+| :------------ | :----: |:----------------------|
+| communityId   | string | Community ID          |
+| communityPhoto| string | Image's url or base64 |
+
+### Optionals 
+
+| Attributes| Type | Description|
+| :-------- | :--: | :-------- |
+
+---
+
+## Request Body
+
+#### URL
+
+Method
+
+`POST` https://api.z-api.io/instances/YOUR_INSTANCE/token/YOUR_TOKEN/update-community-photo
+
+#### Body
+
+```json
+{
+  "communityId": "string",
+  "communityPhoto": "https://www.z-api.io/wp-content/themes/z-api/dist/images/logo.svg"
+}
+```
+
+::::tip Send Base64 image 
+
+If you have doubts about how to send a Base64 image, access the "Send Image" message topic, there you will find everything you need to know about sending in this format.
+
+::::
+
+---
+
+## Response
+
+### 200
+
+| Attributes| Type    | Description                                         |
+| :-------- | :------ | :-------------------------------------------------- |
+| value     | boolean | true if it worked and false if it failed |
+
+Example
+
+```json
+{
+  "value": true
+}
+```
+
+### 405
+
+In this case certify that you are sending the correct specification of the method. This means, verify if you sent a POST or GET as specified at the beginning of this topic.
+
+### 415
+
+In case you receive 415 error, make sure to add the "Content-Type" of the object you are sending in the request headers, mostly "application/json"
+
+---
+
+## Webhook Response
+
+Link to webhook response (on receipt)
+
+[Webhook](../webhooks/on-message-received#response)
+
+---
+
+## Code
+
+<iframe src="//api.apiembed.com/?source=https://raw.githubusercontent.com/Z-API/z-api-docs/main/json-examples/update-community-photo.json&targets=all" frameborder="0" scrolling="no" width="100%" height="500px" seamless></iframe>

--- a/json-examples/update-community-photo.json
+++ b/json-examples/update-community-photo.json
@@ -1,0 +1,21 @@
+{
+    "method": "POST",
+    "url": "https://api.z-api.io/instances/SUA_INSTANCIA/token/SEU_TOKEN/update-community-photo",
+    "httpVersion": "HTTP/1.1",
+    "queryString": [],
+    "headers": [
+        {
+            "name": "Content-Type",
+            "value": "application/json"
+        },
+        {
+            "name": "Client-Token",
+            "value": "{{security-token}}"
+        }
+    ],
+    "cookies": [],
+    "postData": {
+        "mimeType": "application/json",
+        "text": "{\"communityId\": \"ID da Comunidade\", \"communityPhoto\": \"Url ou Base64 da foto\"}"
+    }
+}


### PR DESCRIPTION
Added new documentation for the /update-community-photo API endpoint in both Portuguese and English. The docs describe the method, required and optional parameters, request/response examples, error handling, and webhook integration.